### PR TITLE
tidy openrouter request parameters and api handlers

### DIFF
--- a/api/v1/openrouter/completions.go
+++ b/api/v1/openrouter/completions.go
@@ -5,12 +5,10 @@ import (
 	"crynux_bridge/api/v1/openrouter/structs"
 	"crynux_bridge/api/v1/openrouter/utils"
 	"crynux_bridge/api/v1/response"
-	"crynux_bridge/api/v1/tools"
 	"crynux_bridge/config"
 	"crynux_bridge/models"
 	"encoding/json"
 	"errors"
-	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -29,22 +27,10 @@ func Completions(c *gin.Context, in *CompletionsRequest) (*structs.CompletionsRe
 	/* 1. Build TaskInput from CompletionsRequest */
 	in.SetDefaultValues() // set default values for some fields
 
-	if !strings.HasPrefix(in.Authorization, "Bearer ") {
-		return nil, response.NewValidationErrorResponse("Authorization", "Authorization header must start with 'Bearer '")
-	}
-	apiKeyStr := in.Authorization[7:]
-	apiKey, err := tools.ValidateAPIKey(c.Request.Context(), config.GetDB(), apiKeyStr)
+	// validate request (apiKey)
+	apiKey, err := ValidateRequestApiKey(ctx, db, in.Authorization)
 	if err != nil {
-		if errors.Is(err, tools.ErrAPIKeyExpired) {
-			return nil, response.NewValidationErrorResponse("Authorization", "expired")
-		}
-		if errors.Is(err, tools.ErrAPIKeyInvalid) {
-			return nil, response.NewValidationErrorResponse("Authorization", "unauthorized")
-		}
-		return nil, response.NewExceptionResponse(err)
-	}
-	if !slices.Contains(apiKey.Roles, models.RoleAdmin) && !slices.Contains(apiKey.Roles, models.RoleChat) {
-		return nil, response.NewValidationErrorResponse("Authorization", "unauthorized")
+		return nil, err
 	}
 
 	messages := make([]structs.Message, 1)

--- a/api/v1/openrouter/process_gpt_task.go
+++ b/api/v1/openrouter/process_gpt_task.go
@@ -18,7 +18,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// func ProcessGPTTask(c *gin.Context, in *inference_tasks.TaskInput) (*structs.GPTTaskResponse, *models.InferenceTask, error) {
 func ProcessGPTTask(ctx context.Context, db *gorm.DB, in *inference_tasks.TaskInput) (*structs.GPTTaskResponse, *models.InferenceTask, error) {
 	/* 1. Create GPT task by function CreateTask */
 	taskResponse, err := inference_tasks.DoCreateTask(ctx, in)

--- a/api/v1/openrouter/structs/chat_completions.go
+++ b/api/v1/openrouter/structs/chat_completions.go
@@ -2,37 +2,46 @@ package structs
 
 import "encoding/json"
 
+/* Request */
+
 type ChatCompletionsRequest struct {
-	Messages          []CCReqMessage           `json:"messages" validate:"required"`
-	Model             string                   `json:"model" validate:"required"`
+	Model             string             `json:"model" validate:"required"`
+	Messages          []CCReqMessage     `json:"messages" validate:"required"`
+	Stream            bool               `json:"stream"` // default to false
+	MaxTokens         *int               `json:"max_tokens"`
+	Temperature       float64            `json:"temperature"`
+	Seed              int                `json:"seed"`
+	TopP              *float64           `json:"top_p"`
+	TopK              *int               `json:"top_k"`
+	FrequencyPenalty  *float64           `json:"frequency_penalty"`
+	PresencePenalty   *float64           `json:"presence_penalty"`
+	RepetitionPenalty *float64           `json:"repetition_penalty"`
+	LogitBias         map[string]float64 `json:"logit_bias"`
+	TopLogprobs       int                `json:"top_logprobs"`
+	MinP              *float64           `json:"min_p"`
+	TopA              *float64           `json:"top_a"`
+
+	// Transforms []string `json:"transforms"` // openrouter only
+	// Models     []string `json:"models"`
+	// Provider   TODO     `json:"provider"`
+	// Reasoning  TODO     `json:"reasoning"`
+
+	Stop []string `json:"stop"`
+
 	Audio             *CCReqAudio              `json:"audio"`
-	FrequencyPenalty  *float64                 `json:"frequency_penalty"`
-	LogitBias         map[string]float64       `json:"logit_bias"`
 	LogProbs          bool                     `json:"logprobs"`
-	MaxTokens         *int                     `json:"max_tokens"`
 	MetaData          map[string]string        `json:"metadata"`
 	Modalities        []string                 `json:"modalities"`
 	N                 int                      `json:"n" default:"1"`
 	Prediction        *CCReqPrediction         `json:"prediction"`
-	PresencePenalty   *float64                 `json:"presence_penalty,omitempty"`
-	RepetitionPenalty *float64                 `json:"repetition_penalty"`
 	ReasoningEffort   string                   `json:"reasoning_effort"`
 	ResponseFormat    map[string]interface{}   `json:"response_format"`
 	StructuredOutputs bool                     `json:"structured_outputs"`
-	Seed              int                      `json:"seed"`
 	ServiceTier       string                   `json:"service_tier"`
-	Stop              []string                 `json:"stop"`
 	Store             bool                     `json:"store"`
-	Stream            bool                     `json:"stream"`
 	StreamOptions     *CCReqStreamOptions      `json:"stream_options"`
-	Temperature       float64                  `json:"temperature"`
 	ToolChoice        []map[string]interface{} `json:"tool_choice"`
 	Tools             []map[string]interface{} `json:"tools"`
-	TopLogprobs       int                      `json:"top_logprobs"`
-	TopP              *float64                 `json:"top_p"`
-	TopK              *int                     `json:"top_k"`
-	MinP              *float64                 `json:"min_p"`
-	TopA              *float64                 `json:"top_a"`
 	User              string                   `json:"user"`
 	WebSearchOptions  json.RawMessage          `json:"web_search_options"`
 }
@@ -46,7 +55,7 @@ func (ccr *ChatCompletionsRequest) SetDefaultValues() {
 // Chat Completions Request Message
 type CCReqMessage struct {
 	Role       ChatCompletionsRole    `json:"role" validate:"required"`
-	Content    string                 `json:"content"`
+	Content    string                 `json:"content" validate:"required"`
 	Name       string                 `json:"name"`
 	Audio      *CCReqMessageAudio     `json:"audio"`
 	Refusal    string                 `json:"refusal"`
@@ -102,6 +111,8 @@ type CCReqAudio struct {
 	Format string `json:"format" validate:"required"`
 	Voice  string `json:"voice" validate:"required"`
 }
+
+/* Response */
 
 type ChatCompletionsResponse struct {
 	Id          string        `json:"id"`

--- a/api/v1/openrouter/structs/completions.go
+++ b/api/v1/openrouter/structs/completions.go
@@ -1,28 +1,38 @@
 package structs
 
+/* Request */
+
 type CompletionsRequest struct {
 	Model             string             `json:"model" validate:"required"`
 	Prompt            string             `json:"prompt" validate:"required"`
-	BestOf            int                `json:"best_of"` // defaults to 1
-	Echo              bool               `json:"echo"`
-	FrequencyPenalty  *float64           `json:"frequency_penalty"`
-	LogitBias         map[string]float64 `json:"logit_bias"`
-	LogProbs          int                `json:"logprobs"`
+	Stream            bool               `json:"stream"` // default to false
 	MaxTokens         *int               `json:"max_tokens"`
-	N                 int                `json:"n" default:"1"`
-	PresencePenalty   *float64           `json:"presence_penalty"`
-	RepetitionPenalty *float64           `json:"repetition_penalty"`
-	Seed              int                `json:"seed"`
-	Stop              []string           `json:"stop"`
-	Stream            bool               `json:"stream"`
-	StreamOptions     CReqStreamOptions  `json:"stream_options"`
-	Suffix            string             `json:"suffix"`
 	Temperature       float64            `json:"temperature"`
+	Seed              int                `json:"seed"`
 	TopP              *float64           `json:"top_p"`
 	TopK              *int               `json:"top_k"`
+	FrequencyPenalty  *float64           `json:"frequency_penalty"`
+	PresencePenalty   *float64           `json:"presence_penalty"`
+	RepetitionPenalty *float64           `json:"repetition_penalty"`
+	LogitBias         map[string]float64 `json:"logit_bias"`
+	TopLogprobs       int                `json:"top_logprobs"`
 	MinP              *float64           `json:"min_p"`
 	TopA              *float64           `json:"top_a"`
-	User              string             `json:"user"`
+
+	// Transforms []string `json:"transforms"` // openrouter only
+	// Models     []string `json:"models"`
+	// Provider   TODO     `json:"provider"`
+	// Reasoning  TODO     `json:"reasoning"`
+
+	Stop []string `json:"stop"`
+
+	BestOf        int               `json:"best_of"` // defaults to 1
+	Echo          bool              `json:"echo"`
+	LogProbs      int               `json:"logprobs"`
+	N             int               `json:"n" default:"1"`
+	StreamOptions CReqStreamOptions `json:"stream_options"`
+	Suffix        string            `json:"suffix"`
+	User          string            `json:"user"`
 }
 
 func (cr *CompletionsRequest) SetDefaultValues() {
@@ -35,6 +45,8 @@ type CReqStreamOptions struct {
 	IncludeUsage bool `json:"include_usage"`
 }
 
+/* Response */
+
 type CompletionsResponse struct {
 	Id                string       `json:"id"`
 	Object            string       `json:"object"`
@@ -42,7 +54,7 @@ type CompletionsResponse struct {
 	Model             string       `json:"model"`
 	SystemFingerprint string       `json:"system_fingerprint"`
 	Choices           []CResChoice `json:"choices"`
-	Usage             CReqUsage    `json:"usage"`
+	Usage             CResUsage    `json:"usage"`
 }
 
 type CResChoice struct {
@@ -52,7 +64,7 @@ type CResChoice struct {
 	FinishReason string `json:"finish_reason"`
 }
 
-type CReqUsage struct {
+type CResUsage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`

--- a/api/v1/openrouter/utils/converter.go
+++ b/api/v1/openrouter/utils/converter.go
@@ -109,8 +109,8 @@ func ResponseChoiceToCResChoice(responseChoice structs.ResponseChoice) (structs.
 	return cResChoice, nil
 }
 
-func UsageToCResUsage(usage structs.Usage) structs.CReqUsage {
-	var cResUsage structs.CReqUsage
+func UsageToCResUsage(usage structs.Usage) structs.CResUsage {
+	var cResUsage structs.CResUsage
 	cResUsage.PromptTokens = usage.PromptTokens
 	cResUsage.CompletionTokens = usage.CompletionTokens
 	cResUsage.TotalTokens = usage.TotalTokens

--- a/api/v1/openrouter/validate_api_key.go
+++ b/api/v1/openrouter/validate_api_key.go
@@ -1,0 +1,36 @@
+package openrouter
+
+import (
+	"context"
+	"crynux_bridge/api/v1/response"
+	"crynux_bridge/api/v1/tools"
+	"crynux_bridge/models"
+	"errors"
+	"slices"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// validate api key
+func ValidateRequestApiKey(ctx context.Context, db *gorm.DB, authorization string) (*models.ClientAPIKey, error) {
+	if !strings.HasPrefix(authorization, "Bearer ") {
+		return nil, response.NewValidationErrorResponse("Authorization", "Authorization header must start with 'Bearer '")
+	}
+	apiKeyStr := authorization[7:]
+	apiKey, err := tools.ValidateAPIKey(ctx, db, apiKeyStr)
+	if err != nil {
+		if errors.Is(err, tools.ErrAPIKeyExpired) {
+			return nil, response.NewValidationErrorResponse("Authorization", "expired")
+		}
+		if errors.Is(err, tools.ErrAPIKeyInvalid) {
+			return nil, response.NewValidationErrorResponse("Authorization", "unauthorized")
+		}
+		return nil, response.NewExceptionResponse(err)
+	}
+	if !slices.Contains(apiKey.Roles, models.RoleAdmin) && !slices.Contains(apiKey.Roles, models.RoleChat) {
+		return nil, response.NewValidationErrorResponse("Authorization", "unauthorized")
+	}
+
+	return apiKey, nil
+}


### PR DESCRIPTION
1. Tidy openrouter request parameters in such order: params in openrouter api reference, params in openrouter provider form, params in openai api docs.
2. Define a function ValidateRequestApiKey in api/v1/openrouter/validate_api_key.go, invoke it in completions.go and chat_completions.go
3. Fix a spelling error: CResUsage ( mistakenly spelled CReqUsage before )